### PR TITLE
Adding variation filtering on the front end

### DIFF
--- a/1984-connector-for-dk-and-woocommerce.php
+++ b/1984-connector-for-dk-and-woocommerce.php
@@ -26,6 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 new Hooks\Admin();
+new Hooks\Frontend();
 new Cron\Schedule();
 new Rest\Settings();
 new Rest\OrderDKInvoice();

--- a/src/Hooks/Frontend.php
+++ b/src/Hooks/Frontend.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace NineteenEightyFour\NineteenEightyWoo\Hooks;
+
+use NineteenEightyFour\NineteenEightyWoo\Config;
+use NineteenEightyFour\NineteenEightyWoo\Import\ProductVariations as ProductVariations;
+
+/**
+ * The frontend class
+ *
+ * Handles things that happen on the public-facing portion of the store.
+ */
+class Frontend {
+	/**
+	 * The contstructor
+	 */
+	public function __construct() {
+		if ( Config::get_use_attribute_value_description() ) {
+			add_filter(
+				'woocommerce_variation_option_name',
+				array( __CLASS__, 'filter_variation_attribute_value' ),
+				10,
+				4
+			);
+		}
+
+		if ( Config::get_use_attribute_description() ) {
+			add_filter(
+				'woocommerce_attribute_label',
+				array( __CLASS__, 'filter_variation_attribute_label' ),
+				10,
+				1
+			);
+		}
+	}
+
+	/**
+	 * Filter attribute labels
+	 *
+	 * @param string $label The label code as set in WC and DK.
+	 */
+	public static function filter_variation_attribute_label( string $label ): string {
+		$saved_attribute = ProductVariations::get_attribute( $label );
+
+		if ( ! is_object( $saved_attribute ) ) {
+			return (string) $label;
+		}
+
+		return $saved_attribute->description;
+	}
+
+	/**
+	 * Filter attribute values
+	 *
+	 * @param string $name The value/name code as set in WC and DK.
+	 */
+	public static function filter_variation_attribute_value( string $name ): string {
+		return ProductVariations::get_attribute_name( $name );
+	}
+}

--- a/views/admin.php
+++ b/views/admin.php
@@ -172,7 +172,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p>
 				<?php
 				esc_html_e(
-					'While the variation and attribute codes from DK are used internally, their values can be displayed as the descriptions that are set for each of them in DK. Here you can also enable the product conversion feature.',
+					'While the variation and attribute codes from DK are used internally, their values can be displayed as the descriptions that are set for each of them in DK.',
 					'1984-dk-woo'
 				);
 				?>


### PR DESCRIPTION
This should enable "human readable" prouct variation menus, instead of displaying the DK variant codes.

Weirdly this was missing from the main branch, but it has been added again.