### PR TITLE
Introducing support for product discounts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,28 @@
         "psy/psysh": "^0.12.0",
         "yoast/phpunit-polyfills": "^2.0",
         "aldavigdis/wp-tests-strapon": "^0.1",
-        "woocommerce/woocommerce": "9.8.5"
+        "woocommerce/woocommerce": "10.2.2",
+        "woocommerce/wc-smooth-generator": "1.2.2"
     },
     "repositories": [
         {
             "type": "package",
             "package": {
                 "name": "woocommerce/woocommerce",
-                "version": "9.8.5",
+                "version": "10.2.2",
                 "dist": {
-                    "url": "https://github.com/woocommerce/woocommerce/releases/download/9.8.5/woocommerce.zip",
+                    "url": "https://github.com/woocommerce/woocommerce/releases/download/10.2.2/woocommerce.zip",
+                    "type": "zip"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "woocommerce/wc-smooth-generator",
+                "version": "1.2.2",
+                "dist": {
+                    "url": "https://github.com/woocommerce/wc-smooth-generator/releases/download/1.2.2/wc-smooth-generator.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2333145582dbe3b4653bd7b9d24f5ed",
+    "content-hash": "900bf4626524005599dfa4126043132f",
     "packages": [
         {
             "name": "brick/math",
@@ -1426,16 +1426,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.55",
+            "version": "10.5.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4b2d546b336876bd9562f24641b08a25335b06b6"
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b2d546b336876bd9562f24641b08a25335b06b6",
-                "reference": "4b2d546b336876bd9562f24641b08a25335b06b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
                 "shasum": ""
             },
             "require": {
@@ -1459,7 +1459,7 @@
                 "sebastian/comparator": "^5.0.4",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.2",
+                "sebastian/exporter": "^5.1.4",
                 "sebastian/global-state": "^6.0.2",
                 "sebastian/object-enumerator": "^5.0.0",
                 "sebastian/recursion-context": "^5.0.1",
@@ -1507,7 +1507,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.55"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
             },
             "funding": [
                 {
@@ -1531,7 +1531,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-14T06:19:20+00:00"
+            "time": "2025-09-28T12:04:46+00:00"
         },
         {
             "name": "psr/container",
@@ -1588,16 +1588,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.10",
+            "version": "v0.12.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "6e80abe6f2257121f1eb9a4c55bf29d921025b22"
+                "reference": "cd23863404a40ccfaf733e3af4db2b459837f7e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/6e80abe6f2257121f1eb9a4c55bf29d921025b22",
-                "reference": "6e80abe6f2257121f1eb9a4c55bf29d921025b22",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/cd23863404a40ccfaf733e3af4db2b459837f7e7",
+                "reference": "cd23863404a40ccfaf733e3af4db2b459837f7e7",
                 "shasum": ""
             },
             "require": {
@@ -1660,9 +1660,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.10"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.12"
             },
-            "time": "2025-08-04T12:39:37+00:00"
+            "time": "2025-09-20T13:46:31+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2112,16 +2112,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.2",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
@@ -2130,7 +2130,7 @@
                 "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -2178,15 +2178,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T07:17:12+00:00"
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -2806,16 +2818,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.3",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7"
+                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
-                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
+                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
                 "shasum": ""
             },
             "require": {
@@ -2880,7 +2892,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.3"
+                "source": "https://github.com/symfony/console/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -2900,7 +2912,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-25T06:35:40+00:00"
+            "time": "2025-09-22T15:31:00+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3389,16 +3401,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.3",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c"
+                "reference": "f96476035142921000338bad71e5247fbc138872"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
-                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f96476035142921000338bad71e5247fbc138872",
+                "reference": "f96476035142921000338bad71e5247fbc138872",
                 "shasum": ""
             },
             "require": {
@@ -3413,7 +3425,6 @@
             },
             "require-dev": {
                 "symfony/emoji": "^7.1",
-                "symfony/error-handler": "^6.4|^7.0",
                 "symfony/http-client": "^6.4|^7.0",
                 "symfony/intl": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
@@ -3456,7 +3467,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.3"
+                "source": "https://github.com/symfony/string/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -3476,20 +3487,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-25T06:35:40+00:00"
+            "time": "2025-09-11T14:36:48+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.3",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f"
+                "reference": "b8abe7daf2730d07dfd4b2ee1cecbf0dd2fbdabb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
-                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b8abe7daf2730d07dfd4b2ee1cecbf0dd2fbdabb",
+                "reference": "b8abe7daf2730d07dfd4b2ee1cecbf0dd2fbdabb",
                 "shasum": ""
             },
             "require": {
@@ -3543,7 +3554,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -3563,7 +3574,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2025-09-11T10:12:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3616,11 +3627,20 @@
             "time": "2024-03-03T12:36:25+00:00"
         },
         {
-            "name": "woocommerce/woocommerce",
-            "version": "9.8.5",
+            "name": "woocommerce/wc-smooth-generator",
+            "version": "1.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/woocommerce/woocommerce/releases/download/9.8.5/woocommerce.zip"
+                "url": "https://github.com/woocommerce/wc-smooth-generator/releases/download/1.2.2/wc-smooth-generator.zip"
+            },
+            "type": "library"
+        },
+        {
+            "name": "woocommerce/woocommerce",
+            "version": "10.2.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/woocommerce/woocommerce/releases/download/10.2.2/woocommerce.zip"
             },
             "type": "library"
         },

--- a/connector-for-dk.php
+++ b/connector-for-dk.php
@@ -28,6 +28,7 @@ require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 new Hooks\Admin();
 new Hooks\CustomerDiscounts();
 new Hooks\Frontend();
+new Hooks\OrderMeta();
 new Cron\Schedule();
 new Rest\Settings();
 new Rest\OrderDKInvoice();

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,9 @@ Always back up your accounting records, site data and disable any plugin that ma
 * Improved support for international orders and customers
 * Added support for per-customer price groups and discounts
 * Improved the prescision of imported product sales prices, rounding them down
+* Introducing support for item discounts on invoices and in the Order Editor
+* Products no longer need to be available in order for invoices to be generated
+* Invoice generation is now limited to orders made with the plugin installed
 
 == Frequently Asked Questions ==
 

--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -62,6 +62,10 @@ class Invoice {
 		$api_request  = new DKApiRequest();
 		$request_body = self::to_dk_invoice_body( $wc_order );
 
+		if ( ! $request_body ) {
+			return false;
+		}
+
 		$result = $api_request->request_result(
 			self::API_PATH,
 			wp_json_encode( $request_body ),
@@ -236,12 +240,16 @@ class Invoice {
 	 *
 	 * @param WC_Order $wc_order The WooCommerce order.
 	 *
-	 * @return array An associative array representing the JSON request body.
+	 * @return array|false An associative array representing the JSON request body. False on failure.
 	 */
 	public static function to_dk_invoice_body(
 		WC_Order $wc_order,
-	): array {
+	): array|false {
 		$invoice_body = ExportOrder::to_dk_order_body( $wc_order );
+
+		if ( ! $invoice_body ) {
+			return false;
+		}
 
 		$invoice_body['SalesPerson'] = Config::get_default_sales_person_number();
 		$invoice_body['Text2']       = $wc_order->get_customer_note( 'view' );

--- a/src/Helpers/Customer.php
+++ b/src/Helpers/Customer.php
@@ -109,4 +109,25 @@ class Customer {
 			STR_PAD_LEFT
 		);
 	}
+
+	/**
+	 * Get the DK price group for a customer
+	 *
+	 * @param WC_Customer $customer The customer.
+	 */
+	public static function get_dk_price_group(
+		WC_Customer $customer
+	): string {
+		$group = (string) $customer->get_meta(
+			'connector_for_dk_price_group',
+			true,
+			'edit'
+		);
+
+		if ( $group === '0' ) {
+			$group = '1';
+		}
+
+		return $group;
+	}
 }

--- a/src/Helpers/Order.php
+++ b/src/Helpers/Order.php
@@ -24,11 +24,11 @@ class Order {
 	 * @return bool True if the order can be invoiced, false if not.
 	 */
 	public static function can_be_invoiced( WC_Order $wc_order ): bool {
-		foreach ( $wc_order->get_items() as $order_item ) {
-			if ( $order_item->get_product() === false ) {
-				return false;
-			}
+		if ( empty( $wc_order->get_meta( 'connector_for_dk_version', true, 'edit' ) ) ) {
+			return false;
+		}
 
+		foreach ( $wc_order->get_items() as $order_item ) {
 			if ( $order_item instanceof WC_Order_Item_Product ) {
 				if ( empty( $order_item->get_product()->get_sku() ) ) {
 					return false;

--- a/src/Hooks/OrderMeta.php
+++ b/src/Hooks/OrderMeta.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AldaVigdis\ConnectorForDK\Hooks;
+
+use AldaVigdis\ConnectorForDK\Config;
+use AldaVigdis\ConnectorForDK\Helpers\Product as ProductHelper;
+use AldaVigdis\ConnectorForDK\Helpers\Customer as CustomerHelper;
+
+use AldaVigdis\ConnectorForDK\Brick\Math\BigDecimal;
+use AldaVigdis\ConnectorForDK\Brick\Math\RoundingMode;
+
+use WC_Customer;
+use WC_Order;
+use WC_Order_Item;
+use WC_Product;
+use WC_Order_Item_Product;
+use WC_Product_Variation;
+
+/**
+ * The Order Meta class
+ *
+ * Used for collecting meta data for order items, hooking into new orders and
+ * modifying the order table view in wp-admin to accommidate customer prices and
+ * discounts.
+ */
+class OrderMeta {
+	/**
+	 * The constructor
+	 */
+	public function __construct() {
+		if ( Config::get_enable_dk_customer_prices() ) {
+			add_action(
+				'woocommerce_admin_order_item_headers',
+				array( __CLASS__, 'add_original_price_to_order_thead' ),
+				10,
+				1
+			);
+
+			add_action(
+				'woocommerce_admin_order_item_values',
+				array( __CLASS__, 'add_original_price_to_order_table' ),
+				10,
+				2
+			);
+		}
+
+		add_action(
+			'woocommerce_new_order',
+			array( __CLASS__, 'add_meta_to_order_items' ),
+			10,
+			2
+		);
+
+		add_action(
+			'woocommerce_update_order',
+			array( __CLASS__, 'add_meta_to_order_items' ),
+			10,
+			2
+		);
+
+		add_filter(
+			'woocommerce_order_item_get_formatted_meta_data',
+			array( __CLASS__, 'hide_item_meta_from_order' ),
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Add original price to order table header
+	 *
+	 * @param WC_Order $order The order.
+	 */
+	public static function add_original_price_to_order_thead(
+		WC_Order $order
+	): void {
+		$price_group = $order->get_meta( 'connector_for_dk_price_group' );
+
+		if ( in_array( $price_group, array( '2', '3' ), true ) ) {
+			$price_group_label = sprintf(
+				// Translators: The %s is the numeric "price group" the customer is in.
+				__( 'Group Price %s', 'connector-for-dk' ),
+				$price_group
+			);
+		} else {
+			$price_group_label = __( 'List Price', 'connector-for-dk' );
+		}
+
+		echo '<th class="group_price sortable" data-sort="float">';
+		echo esc_html( $price_group_label );
+		echo '</th>';
+	}
+
+	/**
+	 * Add original price to order table
+	 *
+	 * Displays the original price or group price in the order table body
+	 *
+	 * @param WC_Product|false|null    $product The product.
+	 * @param WC_Order_Item|false|null $item The order item.
+	 */
+	public static function add_original_price_to_order_table(
+		WC_Product|false|null $product,
+		WC_Order_Item|false|null $item
+	): void {
+		// Empty cells if this is a shipping or fee line.
+		if ( ! $item instanceof WC_Order_Item_Product ) {
+			echo '<td class="empty" width="1%"></td>';
+			return;
+		}
+
+		// Indicate that the product is missing if it has been removed.
+		if ( ! $product ) {
+			echo '<td class="empty" width="1%">';
+			esc_attr_e( '(Missing)', 'connector-for-dk' );
+			echo '</td>';
+			return;
+		}
+
+		$group_price_meta = $item->get_meta( 'connector_for_dk_group_price' );
+
+		echo '<td class="group_price" width="1%">';
+		echo esc_html(
+			wc_price(
+				$group_price_meta,
+				array( 'in_span' => false )
+			)
+		);
+		echo '</td>';
+	}
+
+	/**
+	 * Add meta data to order items
+	 *
+	 * Adds required metadata to order items when orders are created
+	 *
+	 * @param null|int $order_id The order ID (unused).
+	 * @param WC_Order $order The order.
+	 */
+	public static function add_meta_to_order_items(
+		?int $order_id,
+		WC_Order $order
+	): void {
+		$customer = new WC_Customer( $order->get_customer_id() );
+
+		foreach ( $order->get_items() as $item ) {
+			if ( ! $item instanceof WC_Order_Item_Product ) {
+				continue;
+			}
+
+			$product = $item->get_product();
+
+			if ( ! $product ) {
+				continue;
+			}
+
+			$group_price = ProductHelper::get_group_price(
+				$product,
+				$customer
+			);
+
+			$subtotal_with_tax = $order->get_item_subtotal(
+				$item,
+				true,
+				false
+			);
+
+			$subtotal_before_tax = $order->get_item_subtotal(
+				$item,
+				false,
+				false
+			);
+
+			$tax_multiplier = BigDecimal::of(
+				$subtotal_with_tax
+			)->dividedBy(
+				$subtotal_before_tax,
+				12,
+				RoundingMode::HALF_UP
+			)->toFloat();
+
+			if ( wc_prices_include_tax() ) {
+				$decimals = (int) get_option(
+					'woocommerce_price_num_decimals',
+					'0'
+				);
+
+				$group_price_after_vat = BigDecimal::of(
+					$group_price
+				)->dividedBy(
+					$tax_multiplier,
+					12,
+					RoundingMode::HALF_UP
+				)->toFloat();
+
+				$item->update_meta_data(
+					'connector_for_dk_group_price',
+					(string) round(
+						$group_price_after_vat,
+						$decimals,
+						PHP_ROUND_HALF_UP
+					)
+				);
+			} else {
+				$item->update_meta_data(
+					'connector_for_dk_group_price',
+					$group_price
+				);
+			}
+
+			$item->update_meta_data(
+				'connector_for_dk_vat_multiplier',
+				(string) round( $tax_multiplier, 2, PHP_ROUND_HALF_UP )
+			);
+
+			if ( $product instanceof WC_Product_Variation ) {
+				$parent = wc_get_product( $product->get_parent_id() );
+
+				$origin = $parent->get_meta(
+					'connector_for_dk_origin',
+					true,
+					'edit'
+				);
+
+				$item->update_meta_data(
+					'connector_for_dk_origin',
+					$origin
+				);
+
+				if ( $origin === 'product_variation' ) {
+					$item->update_meta_data(
+						'connector_for_dk_sku',
+						$parent->get_sku()
+					);
+				} else {
+					$item->update_meta_data(
+						'connector_for_dk_sku',
+						$item->get_product()->get_sku()
+					);
+				}
+			} else {
+				$item->update_meta_data(
+					'connector_for_dk_origin',
+					$product->get_meta(
+						'connector_for_dk_origin',
+						true,
+						'edit'
+					)
+				);
+
+				$item->update_meta_data(
+					'connector_for_dk_sku',
+					$item->get_product()->get_sku()
+				);
+			}
+
+			$item->save_meta_data();
+		}
+
+		$order->update_meta_data(
+			'connector_for_dk_price_group',
+			CustomerHelper::get_dk_price_group( $customer )
+		);
+
+		$order->update_meta_data(
+			'connector_for_dk_version',
+			Admin::ASSET_VERSION
+		);
+
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Hide item meta
+	 *
+	 * @param array $meta The meta data array as passed to the filter.
+	 */
+	public static function hide_item_meta_from_order( array $meta ): array {
+		foreach ( $meta as $i => $m ) {
+			if ( str_starts_with( $m->key, 'connector_for_dk' ) ) {
+				unset( $meta[ $i ] );
+			}
+		}
+
+		return $meta;
+	}
+}

--- a/src/Hooks/WooMetaboxes.php
+++ b/src/Hooks/WooMetaboxes.php
@@ -32,6 +32,8 @@ class WooMetaboxes {
 		'connector_for_dk_credit_invoice_number',
 		'connector_for_dk_invoice_number',
 		'connector_for_dk_last_downstream_sync',
+		'connector_for_dk_price_group',
+		'connector_for_dk_version',
 	);
 
 	/**

--- a/style/admin.css
+++ b/style/admin.css
@@ -525,6 +525,15 @@ table .column-dk_invoice_id .invoice_error {
 	color: #900;
 }
 
+table.woocommerce_order_items td.empty {
+	color: #767676;
+	font-style: italic;
+}
+
+table.woocommerce_order_items .group_price {
+	text-align: right !important;
+}
+
 @media screen and (max-width: 1200px) {
 	#dk_variations_tab .dk-variations .dk-variation {
 		flex-direction: column;

--- a/tests/Export/OrderTest.php
+++ b/tests/Export/OrderTest.php
@@ -6,7 +6,9 @@ namespace AldaVigdis\ConnectorForDK\Tests\Export;
 
 use AldaVigdis\ConnectorForDK\Export\Order as ExportOrder;
 use AldaVigdis\ConnectorForDK\Config;
+use AldaVigdis\ConnectorForDK\Hooks\OrderMeta;
 
+use WC\SmoothGenerator\Generator\Order as OrderGenerator;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -34,28 +36,9 @@ final class OrderTest extends TestCase {
 		return $kennitala;
 	}
 
-	private function fake_address(): array {
-		return array(
-			'first_name' => 'Lorem',
-			'last_name'  => 'Ipsumson',
-			'address_1'  => 'Bankastræti 0',
-			'address_2'  => 'Kjallara',
-			'postcode'   => '101',
-			'city'       => 'Reykjavík',
-			'country'    => 'IS',
-			'phone'      => '555-5555',
-			'email'      => 'loremipsumson@example.com'
-		);
-	}
-
 	private function fake_order(): WC_Order {
-		$order = new WC_Order();
-
-		$order->set_billing_address( $this->fake_address() );
-		$order->set_shipping_address( $this->fake_address() );
-
-		$order->save();
-		$order->save_meta_data();
+		$order = OrderGenerator::generate( true );
+		OrderMeta::add_meta_to_order_items( null, $order );
 
 		return $order;
 	}

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -8,8 +8,10 @@ use AldaVigdis\ConnectorForDK\Currency;
 
 require __DIR__ . '/../vendor/aldavigdis/wp-tests-strapon/bootstrap.php';
 require __DIR__ . '/../vendor/woocommerce/woocommerce/woocommerce.php';
+require __DIR__ . '/../vendor/woocommerce/wc-smooth-generator/wc-smooth-generator.php';
 
 WC_Install::install();
+WC()->init();
 
 Currency::set_rate( 'EUR', 155.55 );
 update_option( 'woocommerce_currency', 'ISK' );


### PR DESCRIPTION
Customer discounts are now indicated on invoices and in the Order Editor.

This also enables invoices to be generated, even after removing any of the products from WooCommerce.

A meta value is set for new orders, indicating the version number of the plugin, which prevents invoices from being generated if the plugin was not installed when the order took place. This is due to all the meta values that get assigned to order items and need to be in place for invoicing to happen.