### PR TITLE
Disabling coupons

### DIFF
--- a/connector-for-dk.php
+++ b/connector-for-dk.php
@@ -26,6 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 new Hooks\Admin();
+new Hooks\Coupons();
 new Hooks\CustomerDiscounts();
 new Hooks\Frontend();
 new Hooks\OrderMeta();

--- a/src/Hooks/Coupons.php
+++ b/src/Hooks/Coupons.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AldaVigdis\ConnectorForDK\Hooks;
+
+/**
+ * The Coupons class
+ *
+ * Currently this is only used for disabling Coupons in WooCommerce as the
+ * plugin does not support coupon discounts at all.
+ */
+class Coupons {
+	/**
+	 * The constructor
+	 */
+	public function __construct() {
+		add_filter(
+			'woocommerce_coupons_enabled',
+			array( __CLASS__, 'disable_coupons' ),
+			PHP_INT_MAX,
+			0
+		);
+	}
+
+	/**
+	 * Disable coupons
+	 */
+	public static function disable_coupons(): false {
+		return false;
+	}
+}

--- a/style/admin.css
+++ b/style/admin.css
@@ -534,6 +534,10 @@ table.woocommerce_order_items .group_price {
 	text-align: right !important;
 }
 
+.wrap.woocommerce tr:has(#woocommerce_enable_coupons) {
+	display: none;
+}
+
 @media screen and (max-width: 1200px) {
 	#dk_variations_tab .dk-variations .dk-variation {
 		flex-direction: column;


### PR DESCRIPTION
Our plugin does not support coupon discounts, so we simply disable them in WooCommerce for the time being.