### PR TITLE
Enabling constants as config parameters

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,7 @@ Always back up your accounting records, site data and disable any plugin that ma
 * Introducing support for item discounts on invoices and in the Order Editor
 * Products no longer need to be available in order for invoices to be generated
 * Invoice generation is now limited to orders made with the plugin installed
+* Enabling arbitrary configuration using PHP constants
 
 == Frequently Asked Questions ==
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -39,6 +39,8 @@ class Config {
 	/**
 	 * Get a configuration option
 	 *
+	 * Checks for the relevant WP option or constant and returns it.
+	 *
 	 * @param string                               $option the option to fetch.
 	 * @param string|int|float|array|stdClass|bool $default The default value.
 	 */
@@ -46,6 +48,13 @@ class Config {
 		string $option,
 		string|int|float|array|stdClass|bool $default = false
 	): string|int|float|array|stdClass|bool {
+		$option_name   = self::PREFIX . $option;
+		$constant_name = strtoupper( $option_name );
+
+		if ( defined( $constant_name ) ) {
+			return constant( $constant_name );
+		}
+
 		return get_option( self::PREFIX . $option, $default );
 	}
 


### PR DESCRIPTION
This enbles the use of PHP/WP constants as configuration parameters. The API key can be set using `CONNECTOR_FOR_DK_DK_API_KEY` for instance.