### PR TITLE
Refreshing when the settings form has been submitted

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -126,7 +126,7 @@ class ConnectorForDK {
 
 		if ( response.ok ) {
 			ConnectorForDK.settingsSubmit().disabled = false;
-			window.scrollTo( 0, 0 );
+			window.location.reload();
 		} else {
 			ConnectorForDK.settingsErrorIndicator().classList.remove( 'hidden' );
 		}


### PR DESCRIPTION
Turns out it wasn't a good idea not to refresh the settings page. Oh well...