### PR TITLE
Adding an index.php file to the invoice directory

### DIFF
--- a/src/InvoicePDF.php
+++ b/src/InvoicePDF.php
@@ -193,11 +193,31 @@ class InvoicePDF {
 			self::UPLOADS_DIR_NAME
 		);
 
+		$index_path = path_join(
+			$directory_path,
+			'index.php'
+		);
+
+		$index_contents  = "<?php http_response_code( 403 ); ?>\n";
+		$index_contents .= "<html>\n";
+		$index_contents .= "\t<body>\n";
+		$index_contents .= "\t\t<h1>403 Forbidden</h1>\n";
+		$index_contents .= "\t\t<p>Perhaps you shouldn't be here, eh?</p>\n";
+		$index_contents .= "\t</body>";
+		$index_contents .= "</html>\n";
+
 		if (
 			! $wp_filesystem->is_dir( $directory_path ) &&
 			$wp_filesystem->is_writable( dirname( $directory_path ) )
 		) {
-			return $wp_filesystem->mkdir( $directory_path, self::FS_CHMOD_DIR );
+			return (
+				$wp_filesystem->mkdir( $directory_path, self::FS_CHMOD_DIR ) &&
+				$wp_filesystem->put_contents(
+					$index_path,
+					$index_contents,
+					self::FS_CHMOD_FILE
+				)
+			);
 		}
 
 		return false;


### PR DESCRIPTION
This introduces a file that returns a 403 error when a user attempts to access the invoice directory. This is an extra measure on top of directory listings being blocked by default on the web server.