### PR TITLE
Fixing blocked customes handling

### DIFF
--- a/src/BlockedCustomers.php
+++ b/src/BlockedCustomers.php
@@ -78,13 +78,12 @@ class BlockedCustomers {
 		WP_REST_Request $request
 	): mixed {
 		if (
-			$request->get_route() !== '/wc/store/v1/checkout' ||
-			! Config::get_enable_blocked_customers()
+			$request->get_route() !== '/wc/store/v1/checkout'
 		) {
 			return $result;
 		}
 
-		$customer_id = get_current_blog_id();
+		$customer_id = get_current_user_id();
 		$customer    = new WC_Customer( $customer_id );
 
 		if ( $customer->get_meta( 'connector_for_dk_blocked' ) !== '1' ) {
@@ -131,12 +130,13 @@ class BlockedCustomers {
 	 * @throws Exception Exception, containing the error message.
 	 */
 	public static function display_blocked_customer_message(): void {
-		if ( ! Config::get_enable_blocked_customers() ) {
+		$customer_id = get_current_user_id();
+
+		if ( $customer_id === 0 ) {
 			return;
 		}
 
-		$customer_id = get_current_user_id();
-		$customer    = new WC_Customer( $customer_id );
+		$customer = new WC_Customer( $customer_id );
 
 		if ( $customer->get_meta( 'connector_for_dk_blocked' ) === '1' ) {
 			throw new Exception(

--- a/src/Config.php
+++ b/src/Config.php
@@ -1019,16 +1019,6 @@ class Config {
 	}
 
 	/**
-	 * Get wether blocking customers is enabled
-	 */
-	public static function get_enable_blocked_customers(): bool {
-		return (bool) self::get_option(
-			'enable_blocked_customers',
-			true
-		);
-	}
-
-	/**
 	 * Get the message that is shown to customers if their account is blocked.
 	 */
 	public static function get_blocked_customers_message(): string {

--- a/views/admin_sections/blocked_customers.php
+++ b/views/admin_sections/blocked_customers.php
@@ -23,40 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		'connector-for-dk'
 	);
 	?>
-	</p>
-
-<table id="dk-invoices-table" class="form-table">
-	<tbody>
-		<tr>
-			<th scope="row" class="column-title column-primary">
-			</th>
-			<td>
-				<input
-					id="enable_blocked_customers_field"
-					name="enable_blocked_customers"
-					type="checkbox"
-					<?php echo esc_attr( Config::get_enable_blocked_customers() ? 'checked' : '' ); ?>
-				/>
-				<label for="enable_blocked_customers_field">
-					<?php
-					esc_html_e(
-						'Block customers in WooCommerce, if they are labelled as blocked in DK',
-						'connector-for-dk'
-					);
-					?>
-				</label>
-				<p class="description">
-					<?php
-					esc_html_e(
-						'Blocking customers is based on matching their Kennitala between WooCommerce and DK.',
-						'connector-for-dk'
-					);
-					?>
-				</p>
-			</td>
-		</tr>
-	</tbody>
-</table>
+</p>
 
 <table class="form-table">
 	<tbody>


### PR DESCRIPTION
Fixing UI usses and bugs when it comes to blocked customers.

Dropping the checkbox/bool option to enable/disable the feature as we can't generate invoices for blocked customers anyway, resulting in a cryptic error from the DK API.

Also fixing a bug that resulted from using the current blog ID but not user ID. *sigh*