### PR TITLE
Fixing VAT calculations in checkout

### DIFF
--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -9,7 +9,6 @@ use AldaVigdis\ConnectorForDK\Config;
 use AldaVigdis\ConnectorForDK\Brick\Math\BigDecimal;
 use AldaVigdis\ConnectorForDK\Brick\Math\RoundingMode;
 use AldaVigdis\ConnectorForDK\Service\DKApiRequest;
-use WP_Exception;
 use WC_Customer;
 use WC_Product;
 use WC_Product_Variation;
@@ -167,9 +166,11 @@ class Product {
 		$tax_rates = $wc_taxes->get_rates( $tax_class );
 
 		if ( empty( $tax_rates ) ) {
-			throw new WP_Exception(
-				esc_attr__( 'Tax rates not initialised', 'connector-for-dk' )
-			);
+			return 0;
+		}
+
+		if ( ! array_key_exists( 'rate', $tax_rates ) ) {
+			return 0;
 		}
 
 		return array_pop( $tax_rates )['rate'];


### PR DESCRIPTION
Instead of throwing an error, we are now just returnin 0 if a VAT level is not found for a customer's address.