### PR TITLE
Fixing a bug that caused discounts to be stacked

### DIFF
--- a/src/CustomerDiscounts.php
+++ b/src/CustomerDiscounts.php
@@ -124,13 +124,6 @@ class CustomerDiscounts {
 			);
 
 			add_filter(
-				'woocommerce_product_get_price',
-				array( __CLASS__, 'get_discounted_price' ),
-				10,
-				2
-			);
-
-			add_filter(
 				'woocommerce_product_variation_get_price',
 				array( __CLASS__, 'get_discounted_price' ),
 				10,


### PR DESCRIPTION
Discounts were being applied twice over, as the woocommerce_product_get_price filter was being used when initiating an order.