### PR TITLE
Fixing payment method retreival issues

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -13,6 +13,7 @@ use AldaVigdis\ConnectorForDK\Import\Products;
 use WC_Payment_Gateways;
 use stdClass;
 use WC_Order;
+use WP_Error;
 
 /**
  * The ConnectorForDK Admin class
@@ -559,7 +560,7 @@ class Admin {
 			$class    = 'info';
 			$dashicon = 'dashicons-info';
 		} elseif ( $transient_value || ProductHelper::is_in_dk( $sku ) === true ) {
-			if ( ! $transient_value ) {
+			if ( ! $transient_value || ! $transient_value instanceof WP_Error ) {
 				set_transient( $transient_name, '1', self::TRANSIENT_EXPIRY );
 			}
 

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -602,7 +602,8 @@ class Product {
 		$api_request = new DKApiRequest();
 
 		$result = $api_request->get_result(
-			self::API_PATH . rawurlencode( $sku )
+			self::API_PATH . rawurlencode( $sku ),
+			0.5
 		);
 
 		if ( $result instanceof WP_Error ) {

--- a/src/Import/SalesPayments.php
+++ b/src/Import/SalesPayments.php
@@ -15,7 +15,8 @@ use WP_Error;
  * Provides funtions for handling downstream payment methods from DK
  */
 class SalesPayments {
-	const TRANSIENT_EXPIRY = 600;
+	const TRANSIENT_EXPIRY = 2 * HOUR_IN_SECONDS;
+	const REQUEST_TIMEOUT  = 1;
 
 	const DK_PAYMENT_MODES = array(
 		'ABG',
@@ -45,7 +46,8 @@ class SalesPayments {
 	public static function get_payment_terms_from_dk(): array|WP_Error|false {
 		$request = new DKApiRequest();
 		$result  = $request->get_result(
-			'/general/table/ARPTERM.DAT/records?legacy=true&fields=CODE,DESCRIPTION'
+			'/general/table/ARPTERM.DAT/records?legacy=true&fields=CODE,DESCRIPTION',
+			self::REQUEST_TIMEOUT
 		);
 
 		if ( $result instanceof WP_Error ) {
@@ -102,18 +104,28 @@ class SalesPayments {
 	 * @return array<string>
 	 */
 	public static function get_payment_terms(): array {
-		$terms_transient = get_transient( 'connector_for_dk_payment_terms' );
+		$terms_updated   = get_option( 'connector_for_dk_payment_terms_updated' );
+		$terms_transient = get_option( 'connector_for_dk_payment_terms' );
 
-		if ( is_array( $terms_transient ) ) {
+		if (
+			is_array( $terms_transient ) &&
+			( $terms_updated > time() - HOUR_IN_SECONDS )
+		) {
 			return $terms_transient;
 		}
 
 		if ( is_string( Config::get_dk_api_key() ) ) {
 			$terms = self::get_payment_terms_from_dk();
+
 			if ( is_array( $terms ) ) {
 				$plucked_terms = array_column( $terms, 'CODE' );
 
-				set_transient(
+				update_option(
+					'connector_for_dk_payment_terms_updated',
+					time()
+				);
+
+				update_option(
 					'connector_for_dk_payment_terms',
 					$plucked_terms,
 					self::TRANSIENT_EXPIRY
@@ -134,7 +146,8 @@ class SalesPayments {
 	public static function get_payment_modes_from_dk(): array|WP_Error|false {
 		$request = new DKApiRequest();
 		$result  = $request->get_result(
-			'/general/table/ARPMODE.DAT/records?legacy=true&fields=CODE,DESCRIPTION'
+			'/general/table/ARPMODE.DAT/records?legacy=true&fields=CODE,DESCRIPTION',
+			self::REQUEST_TIMEOUT
 		);
 
 		if ( $result instanceof WP_Error ) {
@@ -190,23 +203,34 @@ class SalesPayments {
 	 * contents of DK_PAYMENT_MODES will be returned.
 	 */
 	public static function get_payment_modes(): array {
+		$modes_updated   = get_option( 'connector_for_dk_payment_modes_updated' );
 		$modes_transient = get_transient( 'connector_for_dk_payment_modes' );
 
-		if ( is_array( $modes_transient ) ) {
+		if (
+			is_array( $modes_transient ) &&
+			( $modes_updated > time() - HOUR_IN_SECONDS )
+		) {
 			return $modes_transient;
 		}
 
 		if ( is_string( Config::get_dk_api_key() ) ) {
-			$modes         = self::get_payment_modes_from_dk();
-			$plucked_modes = array_column( $modes, 'CODE' );
+			$modes = self::get_payment_modes_from_dk();
 
-			set_transient(
-				'connector_for_dk_payment_modes',
-				$plucked_modes,
-				self::TRANSIENT_EXPIRY
-			);
+			if ( is_array( $modes ) ) {
+				$plucked_modes = array_column( $modes, 'CODE' );
 
-			return $plucked_modes;
+				update_option(
+					'connector_for_dk_payment_modes_updated',
+					time()
+				);
+
+				update_option(
+					'connector_for_dk_payment_modes',
+					$plucked_modes
+				);
+
+				return $plucked_modes;
+			}
 		}
 
 		return self::DK_PAYMENT_MODES;
@@ -218,20 +242,34 @@ class SalesPayments {
 	 * Uses a transient to cache the results from the DK API for 24 hours.
 	 */
 	public static function get_methods(): array {
+		$methods_updated   = get_option( 'connector_for_dk_payment_modes_updated' );
 		$methods_transient = get_transient( 'connector_for_dk_payment_methods' );
 
-		if ( ! $methods_transient ) {
-			$methods_from_dk = self::get_methods_from_dk();
-
-			if ( is_array( $methods_from_dk ) ) {
-				self::save_methods( $methods_from_dk );
-				return $methods_from_dk;
-			}
-
-			return [];
+		if (
+			is_array( $methods_transient ) &&
+			( $methods_updated > time() - HOUR_IN_SECONDS )
+		) {
+			return $methods_transient;
 		}
 
-		return $methods_transient;
+		if ( is_string( Config::get_dk_api_key() ) ) {
+			$methods = self::get_methods_from_dk();
+
+			if ( is_array( $methods ) ) {
+				update_option(
+					'connector_for_dk_payment_methods',
+					$methods
+				);
+				update_option(
+					'connector_for_dk_payment_modes_updated',
+					time()
+				);
+
+				return $methods;
+			}
+		}
+
+		return array();
 	}
 
 	/**
@@ -240,7 +278,8 @@ class SalesPayments {
 	public static function get_methods_from_dk(): array|WP_Error|false {
 		$request = new DKApiRequest();
 		$result  = $request->get_result(
-			'/Sales/Payment/Type?include=PaymentId%2CName%2CActive'
+			'/Sales/Payment/Type?include=PaymentId%2CName%2CActive',
+			self::REQUEST_TIMEOUT
 		);
 
 		if ( $result instanceof WP_Error ) {

--- a/src/Service/DKApiRequest.php
+++ b/src/Service/DKApiRequest.php
@@ -64,7 +64,8 @@ class DKApiRequest {
 	 * This uses the `WP_Http` class to fets a API resource from the DK API
 	 * using a GET request.
 	 *
-	 * @param string $path The internal path do the API resource.
+	 * @param string    $path The internal path do the API resource.
+	 * @param float|int $timeout The timeout in seconds.
 	 *
 	 * @return WP_Error|stdClass An object containing a `data` attribute with
 	 *                           the JSON encoded response body and a
@@ -72,7 +73,10 @@ class DKApiRequest {
 	 *                           HTTP response status as an integer, or WP_Error
 	 *                           on failure.
 	 */
-	public function get_result( string $path ): WP_Error|stdClass {
+	public function get_result(
+		string $path,
+		float|int $timeout = self::GET_TIMEOUT
+	): WP_Error|stdClass {
 		if ( empty( Config::get_dk_api_key() ) ) {
 			return new WP_Error(
 				'dk-api-key-missing',
@@ -85,7 +89,7 @@ class DKApiRequest {
 			array(
 				'httpversion' => '1.1',
 				'headers'     => $this->get_headers,
-				'timeout'     => self::GET_TIMEOUT,
+				'timeout'     => $timeout,
 			),
 		);
 


### PR DESCRIPTION
DK tends to grind to a halt during busy hours, which means that it takes a while to connect to each endpoint, making things like the admin page break. Even direct table queries get slow.

This changes the caching strategy for DK payment methods, modes and terms to use ordinary options instead of transients with an expiry time but not deleting them after expiry unless the dkPlus API responds.