### PR TITLE
Fixing off-by-one error with price groups

### DIFF
--- a/src/CustomerDiscounts.php
+++ b/src/CustomerDiscounts.php
@@ -564,7 +564,7 @@ class CustomerDiscounts {
 
 		$wc_customer->update_meta_data(
 			'connector_for_dk_price_group',
-			strval( $dk_customer->PriceGroup )
+			strval( $dk_customer->PriceGroup + 1 )
 		);
 
 		$wc_customer->save_meta_data();


### PR DESCRIPTION
When syncing customer price groups, they were off by one, as "group 1" is identified with integer value 0 and so forth.