### PR TITLE
Accounting for WooCommerce prices being empty

### DIFF
--- a/src/Discounts.php
+++ b/src/Discounts.php
@@ -302,6 +302,10 @@ class Discounts {
 			return $product->get_sale_price( 'edit' );
 		}
 
+		if ( empty( $product->get_price( 'edit' ) ) ) {
+			return '';
+		}
+
 		$incl_tax = wc_prices_include_tax();
 
 		$customer = self::get_current_customer();

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -636,6 +636,10 @@ class Product {
 		float|int $quantity = 0.0,
 		bool|null $incl_tax = null
 	): string {
+		if ( empty( $product->get_price( 'edit' ) ) ) {
+			return '';
+		}
+
 		if ( is_null( $incl_tax ) ) {
 			$incl_tax = get_option( 'woocommerce_tax_display_shop' ) === 'incl';
 		}
@@ -723,6 +727,10 @@ class Product {
 					PHP_ROUND_HALF_UP
 				);
 			}
+		}
+
+		if ( empty( $product->get_price( 'edit' ) ) ) {
+			return '';
 		}
 
 		if ( $including_tax ) {


### PR DESCRIPTION
Products with empty price attributes were causing stability issues in both this plugin and other WordPress components. This should fix that.